### PR TITLE
Fix callback query state error

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -10,7 +10,17 @@ const BOT_TOKEN = process.env.BOT_TOKEN || 'YOUR_BOT_TOKEN_HERE';
 const bot = new Telegraf(BOT_TOKEN);
 
 // Middleware session
-bot.use(session());
+bot.use(session({
+    defaultSession: () => ({})
+}));
+
+// Middleware untuk memastikan session selalu ada
+bot.use((ctx, next) => {
+    if (!ctx.session) {
+        ctx.session = {};
+    }
+    return next();
+});
 
 // File untuk menyimpan data user
 const USER_DATA_FILE = 'user_data.json';


### PR DESCRIPTION
Fixes `TypeError: Cannot set properties of undefined (setting 'state')` by ensuring `ctx.session` is always initialized.

The error occurred because `ctx.session` was sometimes `undefined` when accessed, particularly in callback query handlers. This PR configures the Telegraf session middleware with a `defaultSession` and adds an additional middleware to guarantee `ctx.session` is an object, preventing attempts to set properties on `undefined`.

---
<a href="https://cursor.com/background-agent?bcId=bc-7bf25a5e-8caa-4d13-86b7-87e676f31509">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7bf25a5e-8caa-4d13-86b7-87e676f31509">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>